### PR TITLE
Turn on app_management flag to Puppet apply

### DIFF
--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -94,16 +94,16 @@ RUN apk update && \
   <% else %>
     <% if os == 'ubuntu' or os == 'debian' %>
 RUN apt-get update && \
-    <% if use_puppetfile %><%= r10k_path %> puppetfile install --moduledir /etc/puppetlabs/code/modules && <% end %> FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> && \
+    <% if use_puppetfile %><%= r10k_path %> puppetfile install --moduledir /etc/puppetlabs/code/modules && <% end %> FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management=true && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
     <% elsif os == 'centos' %>
 RUN yum update -y && \
-    <% if use_puppetfile %><%= r10k_path %> puppetfile install --moduledir /etc/puppetlabs/code/modules && <% end %> FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %>&& \
+    <% if use_puppetfile %><%= r10k_path %> puppetfile install --moduledir /etc/puppetlabs/code/modules && <% end %> FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management=true && \
     yum clean all
     <% elsif os == 'alpine' %>
 RUN apk update && \
-    <% if use_puppetfile %><%= r10k_path %> puppetfile install --moduledir /etc/puppetlabs/code/modules && <% end %> FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> && \
+<% if use_puppetfile %><%= r10k_path %> puppetfile install --moduledir /etc/puppetlabs/code/modules && <% end %> FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management=true && \
     rm -rf /var/cache/apk/*
     <% end %>
   <% end %>

--- a/templates/build-aci.sh.erb
+++ b/templates/build-aci.sh.erb
@@ -120,18 +120,18 @@ acbuild run -- rm -rf /var/cache/apk/*
     <% if os == 'ubuntu' or os == 'debian' %>
 acbuild run -- apt-get update
 <% if use_puppetfile %>acbuild run -- <%= r10k_path %> puppetfile install --moduledir /etc/puppetlabs/code/modules<% end %>
-acbuild run -- <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %>
+acbuild run -- <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management=true
 acbuild run -- apt-get clean
 acbuild run -- rm -rf /var/lib/apt/lists/*
     <% elsif os == 'centos' %>
 acbuild run -- yum update -y
 <% if use_puppetfile %>acbuild run -- <%= r10k_path %> puppetfile install --moduledir /etc/puppetlabs/code/modules<% end %>
-acbuild run -- <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %>
+acbuild run -- <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management=true
 acbuild run -- yum clean all
     <% elsif os == 'alpine' %>
 acbuild run -- apk update
 <% if use_puppetfile %>acbuild run -- <%= r10k_path %> puppetfile install --moduledir /etc/puppetlabs/code/modules<% end %>
-acbuild run -- <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %>
+acbuild run -- <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management=true
 acbuild run -- rm -rf /var/cache/apk/*
     <% end %>
   <% end %>


### PR DESCRIPTION
If the Puppetfile includes a module that has an application definition,
the image building processes will fail because the parser does not have
--app_management=true on by default.  This commit adds the
app_management flag since there's no real reason to NOT have it set to
true. In the absence of application defitions, the apply process will
work the same
