### PR TITLE
Add -y flag to all `yum update` commands

### DIFF
--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -51,7 +51,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 <% elsif os == 'centos' %>
-RUN yum update && \
+RUN yum update -y && \
     yum install -y git && \
     <%= gem_path %> install r10k:"$R10K_VERSION" --no-ri --no-rdoc && \
     yum clean all

--- a/templates/build-aci.sh.erb
+++ b/templates/build-aci.sh.erb
@@ -67,7 +67,7 @@ acbuild run -- <%= gem_path %> install r10k:"$R10K_VERSION" --no-ri --no-rdoc
 acbuild run -- apt-get clean
 acbuild run -- rm -rf /var/lib/apt/lists/*
 <% elsif os == 'centos' %>
-acbuild run -- yum update
+acbuild run -- yum update -y
 acbuild run -- yum install -y git
 acbuild run -- <%= gem_path %> install r10k:"$R10K_VERSION" --no-ri --no-rdoc
 acbuild run -- yum clean all


### PR DESCRIPTION
If the -y flag is left off of a yum update command, the build could fail
is updates are required.
