### PR TITLE
(INFRA-117) Fixing rubocop error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -305,7 +305,10 @@ Style/EmptyLiteral:
 Metrics/LineLength:
   Enabled: false
 
-Style/MethodCallParentheses:
+Metrics/BlockLength:
+  Max: 500
+
+Style/MethodCallWithoutArgsParent:
   Enabled: false
 
 Style/MethodDefParentheses:

--- a/lib/puppet/face/aci.rb
+++ b/lib/puppet/face/aci.rb
@@ -1,7 +1,7 @@
 require 'puppet_x/puppetlabs/imagebuilder'
 require 'puppet_x/puppetlabs/imagebuilder_face'
 
-PuppetX::Puppetlabs::ImageBuilder::Face.define(:aci, '0.1.0') do # rubocop:disable Metrics/BlockLength
+PuppetX::Puppetlabs::ImageBuilder::Face.define(:aci, '0.1.0') do
   summary 'Build Aci images and build scripts using Puppet code'
 
   action(:build) do

--- a/lib/puppet/face/docker.rb
+++ b/lib/puppet/face/docker.rb
@@ -1,7 +1,7 @@
 require 'puppet_x/puppetlabs/imagebuilder'
 require 'puppet_x/puppetlabs/imagebuilder_face'
 
-PuppetX::Puppetlabs::ImageBuilder::Face.define(:docker, '0.1.0') do # rubocop:disable Metrics/BlockLength
+PuppetX::Puppetlabs::ImageBuilder::Face.define(:docker, '0.1.0') do
   summary 'Build Docker images and Dockerfiles using Puppet code'
 
   option '--rocker' do
@@ -9,7 +9,7 @@ PuppetX::Puppetlabs::ImageBuilder::Face.define(:docker, '0.1.0') do # rubocop:di
     default_to { false }
   end
 
-  action(:build) do # rubocop:disable Metrics/BlockLength
+  action(:build) do
     summary 'Build a Docker image from Puppet code'
     arguments '[<manifest>]'
     default

--- a/spec/unit/aci_face_spec.rb
+++ b/spec/unit/aci_face_spec.rb
@@ -40,7 +40,7 @@ describe Puppet::Face[:aci, '0.1.0'] do
       end
 
       it 'should have a default value for manifest if not passed explicitly' do
-        image_builder = double()
+        image_builder = double
         allow(image_builder).to receive(:build)
         allow(image_builder).to receive_message_chain(:build_file, :render)
         expect(PuppetX::Puppetlabs::AciBuilder).to receive(:new).with('manifests/init.pp', any_args).and_return(image_builder)

--- a/spec/unit/docker_face_spec.rb
+++ b/spec/unit/docker_face_spec.rb
@@ -42,7 +42,7 @@ describe Puppet::Face[:docker, '0.1.0'] do
       end
 
       it 'should have a default value for manifest if not passed explicitly' do
-        image_builder = double()
+        image_builder = double
         allow(image_builder).to receive(:build)
         allow(image_builder).to receive_message_chain(:build_file, :render)
         expect(PuppetX::Puppetlabs::DockerBuilder).to receive(:new).with('manifests/init.pp', any_args).and_return(image_builder)


### PR DESCRIPTION
Please review the changes.

Fixed rubocop error messages
Error: The `Style/MethodCallParentheses` cop has been renamed to `Style/MethodCallWithoutArgsParentheses`.
Block has too many lines. [66/25] on multiple files
Do not use parentheses for method calls with no arguments.
