### PR TITLE
don't remove lsb-release from debian based image

### DIFF
--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -18,7 +18,7 @@ RUN <% if apt_proxy %>echo "Acquire::HTTP::Proxy \"$APT_PROXY\";" >> /etc/apt/ap
     rm puppetlabs-release-pc1-"$CODENAME".deb && \
     apt-get update && \
     apt-get install --no-install-recommends -y puppet-agent="$PUPPET_AGENT_VERSION"-1"$CODENAME" && \
-    apt-get remove --purge -y lsb-release wget ca-certificates && \
+    apt-get remove --purge -y wget ca-certificates && \
     apt-get autoremove -y && \
     apt-get clean && \
     mkdir -p /etc/puppetlabs/facter/facts.d/ && \


### PR DESCRIPTION
On debian based systems the package lsb-release is needed for facts like :lsbdistid.
As this is needed for a lot of common modules (like apt), it seems reasonable
to not purge the lsb-release package from image.

Fixes #22