### PR TITLE
(MAINT) Leave packages in place for r10k

### DIFF
--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -18,7 +18,7 @@ RUN <% if apt_proxy %>echo "Acquire::HTTP::Proxy \"$APT_PROXY\";" >> /etc/apt/ap
     rm puppetlabs-release-pc1-"$CODENAME".deb && \
     apt-get update && \
     apt-get install --no-install-recommends -y puppet-agent="$PUPPET_AGENT_VERSION"-1"$CODENAME" && \
-    apt-get remove --purge -y wget ca-certificates && \
+    apt-get remove --purge -y wget && \
     apt-get autoremove -y && \
     apt-get clean && \
     mkdir -p /etc/puppetlabs/facter/facts.d/ && \
@@ -58,7 +58,6 @@ RUN rm /usr/lib/ruby/gems/2.3.0/gems/facter-"$FACTER_VERSION"/lib/facter/blockde
 RUN <% if apt_proxy %>echo "Acquire::HTTP::Proxy \"$APT_PROXY\";" >> /etc/apt/apt.conf.d/01proxy && echo 'Acquire::HTTPS::Proxy "false";' >> /etc/apt/apt.conf.d/01proxy && <% end %>apt-get update && \
     apt-get install --no-install-recommends -y git-core && \
     <%= gem_path %> install r10k:"$R10K_VERSION" --no-ri --no-rdoc && \
-    apt-get remove --purge -y git-core && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* <% if apt_proxy %>&& rm -f /etc/apt/apt.conf.d/01proxy<% end %>


### PR DESCRIPTION
The current code is a little over-enthusiastic when it comes to removing
certain packages that are likely to be useful when using r10k to install
modules. This aligns the behaviour with the different distros as well.

Fixes #21