### PR TITLE
Add --https-proxy support

### DIFF
--- a/lib/puppet/face/docker.rb
+++ b/lib/puppet/face/docker.rb
@@ -45,6 +45,10 @@ PuppetX::Puppetlabs::ImageBuilder::Face.define(:docker, '0.1.0') do
       summary 'An HTTP proxy to use for outgoing traffic during build'
     end
 
+    option '--https-proxy STRING' do
+      summary 'An HTTPS proxy to use for outgoing traffic during build'
+    end
+
     option '--autosign-token STRING' do
       summary 'An authentication token used for autosigning master-built images'
     end

--- a/lib/puppet_x/puppetlabs/imagebuilder.rb
+++ b/lib/puppet_x/puppetlabs/imagebuilder.rb
@@ -320,8 +320,12 @@ module PuppetX
         @context[:autosign_token].nil? ? '' : "--build-arg AUTOSIGN_TOKEN=#{@context[:autosign_token]}"
       end
 
-      def proxy_string
-        @context[:http_proxy].nil? ? '' : "--build-arg HTTP_PROXY=#{@context[:http_proxy]}"
+      def http_proxy_string
+        @context[:http_proxy].nil? ? '' : "--build-arg http_proxy=#{@context[:http_proxy]}"
+      end
+
+      def https_proxy_string
+        @context[:https_proxy].nil? ? '' : "--build-arg https_proxy=#{@context[:https_proxy]}"
       end
 
       def apt_proxy_string
@@ -331,9 +335,9 @@ module PuppetX
       def build_command
         dockerfile_path = build_file.save.path
         if @context[:rocker]
-          "rocker build #{autosign_string} #{apt_proxy_string} #{proxy_string} #{string_args} -f #{dockerfile_path} ."
+          "rocker build #{autosign_string} #{apt_proxy_string} #{http_proxy_string} #{https_proxy_string} #{string_args} -f #{dockerfile_path} ."
         else
-          "docker build #{autosign_string} #{apt_proxy_string} #{proxy_string} #{string_args} -t #{@context[:image_name]} -f #{dockerfile_path} ."
+          "docker build #{autosign_string} #{apt_proxy_string} #{http_proxy_string} #{https_proxy_string} #{string_args} -t #{@context[:image_name]} -f #{dockerfile_path} ."
         end
       end
     end

--- a/spec/support/examples/http_proxy_capable_builder.rb
+++ b/spec/support/examples/http_proxy_capable_builder.rb
@@ -7,7 +7,7 @@ shared_examples 'a builder capable of utilising an HTTP proxy' do
       }
     end
     it 'should not pass a proxy as a build argument' do
-      expect(builder.send(:build_command)).not_to include("--build-arg HTTP_PROXY=")
+      expect(builder.send(:build_command)).not_to include("--build-arg http_proxy=")
     end
   end
 
@@ -21,7 +21,7 @@ shared_examples 'a builder capable of utilising an HTTP proxy' do
       }
     end
     it 'should pass the proxy as a build argument' do
-      expect(builder.send(:build_command)).to include("--build-arg HTTP_PROXY=#{proxy}")
+      expect(builder.send(:build_command)).to include("--build-arg http_proxy=#{proxy}")
     end
   end
 end


### PR DESCRIPTION
Adds a command line argument --https-proxy, similar to --http-proxy

Passes the lowercase variants of both (http_proxy, https_proxy) to
docker instead of the uppercase variant, as every tool (wget, curl, ...)
can use the lowercase variant, but a lot of them do not support the uppercase version.

modified the test to reflect  these changes.