### PR TITLE
Allow manifest directory rather than file.

### DIFF
--- a/lib/puppet_x/puppetlabs/imagebuilder.rb
+++ b/lib/puppet_x/puppetlabs/imagebuilder.rb
@@ -61,7 +61,7 @@ module PuppetX
 
       def validate_context
         unless @context[:master]
-          raise InvalidContextError, "specified file #{@context[:manifest]} does not exist" unless File.file?(@context[:manifest])
+          raise InvalidContextError, "specified file #{@context[:manifest]} does not exist" unless File.exist?(@context[:manifest])
         end
         raise InvalidContextError, 'You must provide an image name, either on the command line or in the metadata file' unless @context[:image_name]
       end


### PR DESCRIPTION
`puppet apply` can be given either a single file or a directory [0].
This patch  allows us to build images with a directory rather than
just a single file.

[0] https://docs.puppet.com/puppet/4.9/dirs_manifest.html#with-puppet-apply