### PR TITLE
Check return code of puppet apply.

### DIFF
--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -107,7 +107,8 @@ RUN apk update && \
   <% else %>
     <% if os == 'ubuntu' or os == 'debian' %>
 RUN <% if apt_proxy %>echo "Acquire::HTTP::Proxy \"$APT_PROXY\";" >> /etc/apt/apt.conf.d/01proxy && echo 'Acquire::HTTPS::Proxy "false";' >> /etc/apt/apt.conf.d/01proxy && <% end %>apt-get update && \
-    FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management && \
+    FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --detailed-exitcodes --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management ; \
+    if [ $? -ne 0 ] && [ $? -ne 2 ]; then exit 1; fi && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* <% if apt_proxy %>&& rm -f /etc/apt/apt.conf.d/01proxy<% end %>


### PR DESCRIPTION
Currently the docker build succeeds even if puppet apply does not
succeed.

Puppet apply has a non-standrad system of return codes. It will
return 0 even if it hasn't sucessfully applied the manifest unless
`--detailed-exitcodes` is given. When this is given if it returns
0 or 2 the manifest has been applied sucessfully [0].

This patch makes the docker build fail if the manifest is not
applied successfully.

[0] https://docs.puppet.com/puppet/latest/man/apply.html#OPTIONS