### PR TITLE
Allow specifying of facter variables during puppet apply.

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ USAGE: puppet docker <action> [--from STRING]
 [--expose STRING]
 [--cmd STRING]
 [--entrypoint STRING]
+[--facter_vars KEY=VALUE]
 [--labels KEY=VALUE]
 [--rocker]
 [--[no-]inventory]
@@ -357,6 +358,12 @@ OPTIONS:
   --config-file STRING           - A configuration file with all the metadata
   --entrypoint STRING            - The default entrypoint for the resulting
                                    image
+  --facter_vars KEY=VALUE        - A set of comma-separated KEY=VALUE pairs
+                                   that should be passed to puppet as facter
+                                   variables whilst running `puppet  apply`.
+                                   The KEY will usually be passed in upper
+                                   case since puppet expects facter variables
+                                   in upper case.
   --expose STRING                - A list of ports to be exposed by the
                                    resulting image
   --from STRING                  - The base docker image to use for the

--- a/lib/puppet_x/puppetlabs/imagebuilder.rb
+++ b/lib/puppet_x/puppetlabs/imagebuilder.rb
@@ -29,6 +29,7 @@ module PuppetX
         expose_to_array
         volume_to_array
         entrypoint_to_array
+        facter_vars_to_array
         determine_os
         determine_paths
         determine_if_using_puppetfile
@@ -127,6 +128,10 @@ module PuppetX
 
       def labels_to_array
         value_to_array(:labels)
+      end
+
+      def facter_vars_to_array
+        value_to_array(:facter_vars)
       end
 
       def add_label_schema_labels

--- a/lib/puppet_x/puppetlabs/imagebuilder_face.rb
+++ b/lib/puppet_x/puppetlabs/imagebuilder_face.rb
@@ -109,6 +109,11 @@ module PuppetX
         summary 'Add label-schema compatible labels'
         default_to { false }
       end
+
+      option '--facter_vars KEY=VALUE' do
+        summary 'Set of variables to add to facter.'
+      end
+
     end
   end
 end

--- a/spec/support/examples/imagebuilder.rb
+++ b/spec/support/examples/imagebuilder.rb
@@ -97,6 +97,20 @@ shared_examples 'an image builder' do #rubocop:disable Metrics/BlockLength
     end
   end
 
+  context 'with a single facter variable specified' do
+    let(:args) do
+      {
+        from: from,
+        image_name: image_name,
+        facter_vars: 'KEY=value',
+      }
+    end
+    it 'should expand the facter_vars to an array' do
+      expect(context[:facter_vars]).to include('KEY=value')
+    end
+  end
+
+
   context 'with a master specified' do
     let(:master) { 'puppet.example.com' }
     let(:args) do

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -112,18 +112,18 @@ RUN apk update && \
   <% else %>
     <% if os == 'ubuntu' or os == 'debian' %>
 RUN <% if apt_proxy %>echo "Acquire::HTTP::Proxy \"$APT_PROXY\";" >> /etc/apt/apt.conf.d/01proxy && echo 'Acquire::HTTPS::Proxy "false";' >> /etc/apt/apt.conf.d/01proxy && <% end %>apt-get update && \
-    FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --detailed-exitcodes --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management ; \
+    <% if facter_vars %><% facter_vars.each do |facter_var| %>FACTER_<%= facter_var %> <% end %><% end %> FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --detailed-exitcodes --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management ; \
     rc=$?; if [ $rc -ne 0 ] && [ $rc -ne 2 ]; then exit 1; fi && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* <% if apt_proxy %>&& rm -f /etc/apt/apt.conf.d/01proxy<% end %>
     <% elsif os == 'centos' %>
 RUN yum update -y && \
-    FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management && \
+    <% if facter_vars %><% facter_vars.each do |facter_var| %>FACTER_<%= facter_var %> <% end %><% end %> FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management && \
     yum clean all
     <% elsif os == 'alpine' %>
 RUN apk update && \
-    FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management && \
+    <% if facter_vars %><% facter_vars.each do |facter_var| %>FACTER_<%= facter_var %> <% end %><% end %> FACTER_hostname=<%= hostname %> <%= puppet_path %> apply <%= manifest %> --verbose --show_diff --summarize <% if use_hiera %>--hiera_config=/hiera.yaml<% end %> --app_management && \
     rm -rf /var/cache/apk/*
     <% end %>
   <% end %>


### PR DESCRIPTION
Sometimes you want to push additional variables to facter during
puppet apply. For instance, secrets should not be stored under version
control but are needed when the configuration is applied. In this instance
using passing the secret as a facter variable to puppet is a nice way
of having the configured machine have the secret but not include the secret
in your source code.

This patch lets you specify facter variables at parameters to
`puppet docker build` that are in turn sent to the `puppet apply` call.