### PR TITLE
(MAINT) Changing the default puppet agent and r10k version

### DIFF
--- a/lib/puppet_x/puppetlabs/imagebuilder_face.rb
+++ b/lib/puppet_x/puppetlabs/imagebuilder_face.rb
@@ -22,12 +22,12 @@ module PuppetX
 
       option '--puppet-agent-version STRING' do
         summary 'Version of the Puppet Agent package to install'
-        default_to { '1.8.2' }
+        default_to { '1.10.0' }
       end
 
       option '--r10k-version STRING' do
         summary 'Version of R10k to use for installing modules from Puppetfile'
-        default_to { '2.2.2' }
+        default_to { '2.5.4' }
       end
 
       option '--module-path PATH' do


### PR DESCRIPTION
When I used agent 1.8.2 and r10k on centos7 box, I would get this error on 'puppet docker build':
[4:50 PM] Abir Majumdar: blerg, same error with the master branch of image_build.
[4:50 PM] Abir Majumdar:
    /opt/puppetlabs/puppet/lib/ruby/2.1.0/rubygems/stub_specification.rb:71:in `initialize': No such file or directory @ rb_sysopen - /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/specifications/gettext-setup-0.6.gemspec (Errno::ENOENT)

It was failing on the r10k install. When I switched the versions to the latest agent 1.10.0 and r10k 2.5.4 (as of 2016-04-14) and it worked fine.