### PR TITLE
Add imagebuiler option --r10k-yaml

### DIFF
--- a/lib/puppet_x/puppetlabs/imagebuilder_face.rb
+++ b/lib/puppet_x/puppetlabs/imagebuilder_face.rb
@@ -30,6 +30,11 @@ module PuppetX
         default_to { '2.5.5' }
       end
 
+      option '--r10k-yaml BOOLEAN' do
+        summary 'When yes, copies the r10k.yaml file to the container before running r10k'
+        default_to { false }
+      end
+
       option '--module-path PATH' do
         summary 'A path to a directory containing a set of modules to be copied into the image'
       end

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -75,6 +75,9 @@ RUN apk add --update git && \
     <%= gem_path %> install r10k:"$R10K_VERSION" --no-ri --no-rdoc && \
     rm -rf /var/cache/apk/*
 <% end %>
+<% if r10k_yaml %>
+COPY r10k.yaml /r10k.yaml
+<% end %>
 COPY <%= puppetfile %> /Puppetfile
 RUN <%= r10k_path %> puppetfile install --moduledir /etc/puppetlabs/code/modules
 <% end %>


### PR DESCRIPTION
This PR add’s the option to add an r10k.yaml file to the container before running r10k. This allows you to use all config options from r10k also in the container build.