### PR TITLE
Add —squash option to image builder

### DIFF
--- a/lib/puppet_x/puppetlabs/imagebuilder.rb
+++ b/lib/puppet_x/puppetlabs/imagebuilder.rb
@@ -366,8 +366,12 @@ module PuppetX
         @context[:apt_proxy].nil? ? '' : "--build-arg APT_PROXY=#{@context[:apt_proxy]}"
       end
 
+      def squash_string
+        @context[:squash] ? '--squash' : ''
+      end
+
       def command_build_args
-        "#{autosign_string} #{apt_proxy_string} #{http_proxy_string} #{https_proxy_string} #{string_args}"
+        "#{autosign_string} #{apt_proxy_string} #{http_proxy_string} #{https_proxy_string} #{string_args} #{squash_string}"
       end
 
       def docker_network

--- a/lib/puppet_x/puppetlabs/imagebuilder_face.rb
+++ b/lib/puppet_x/puppetlabs/imagebuilder_face.rb
@@ -124,6 +124,11 @@ module PuppetX
         summary 'Pass the debug flag to the Puppet process used to build the container image'
         default_to { false }
       end
+
+      option '--squash' do
+        summary 'Automatically squash all layers in the generated image'
+        default_to { false }
+      end
     end
   end
 end


### PR DESCRIPTION
Allows users to squash the docker image to one single layer.