### PR TITLE
fix elasticsearch example

### DIFF
--- a/examples/elasticsearch/manifests/init.pp
+++ b/examples/elasticsearch/manifests/init.pp
@@ -14,6 +14,9 @@ Service <| |> { provider => dummy }
 class { 'elasticsearch': }
 elasticsearch::instance { 'es-01':
   status => 'unmanaged',
+  config =>  {
+    'network.host' =>  '0.0.0.0'
+  }
 }
 
 $elasticsearch_cmd = "#!/bin/bash -e\n/usr/share/elasticsearch/bin/elasticsearch -Des.default.path.conf=/etc/elasticsearch/es-01/ -Des.insecure.allow.root=true"


### PR DESCRIPTION
Current elasticsearch version now listens to 127.0.0.1 by default, so
it's unreachable outside the container. This commit fixes it by
listening to 0.0.0.0