### PR TITLE
Updating Dockerfile template to use same factfile name as supplied

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -326,7 +326,10 @@ Style/StringLiterals:
 Style/TrailingCommaInArguments:
   Enabled: True
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: True
+
+Style/TrailingCommaInHashLiteral:
   Enabled: True
 
 Style/GlobalVars:

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -54,7 +54,7 @@ RUN rm /usr/lib/ruby/gems/2.3.0/gems/facter-"$FACTER_VERSION"/lib/facter/blockde
 <% end %>
 
 <% if use_factfile %>
-    COPY <%= factfile %> /etc/puppetlabs/facter/facts.d/custom_facts.txt
+        COPY <%= factfile %> /etc/puppetlabs/facter/facts.d/<%= factfile.split('/')[-1] %>
 <% end %>
 
 <% if use_puppetfile && !master %>

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -54,7 +54,7 @@ RUN rm /usr/lib/ruby/gems/2.3.0/gems/facter-"$FACTER_VERSION"/lib/facter/blockde
 <% end %>
 
 <% if use_factfile %>
-        COPY <%= factfile %> /etc/puppetlabs/facter/facts.d/<%= factfile.split('/')[-1] %>
+    COPY <%= factfile %> /etc/puppetlabs/facter/facts.d/<%= factfile.split('/')[-1] %>
 <% end %>
 
 <% if use_puppetfile && !master %>


### PR DESCRIPTION
This allows the use of structured fact overrides. When we always copy the custom facts file as "custom_facts.txt", it limits us to only string-based facts. When we allow things like .yaml or .json, we can introduce structured fact overrides since we will be placing the file as whatever format the user is feeding in. I think this is more intuitive and makes this tool more powerful.